### PR TITLE
Fix heading text in Step3Challenge

### DIFF
--- a/src/features/caesar-learning/components/Step3Challenge.jsx
+++ b/src/features/caesar-learning/components/Step3Challenge.jsx
@@ -23,7 +23,7 @@ export const Step3Challenge = ({
         <div className="w-12 h-12 bg-gradient-to-r from-yellow-500 to-orange-500 rounded-xl flex items-center justify-center">
           <Trophy className="text-white" size={24} />
         </div>
-        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">ステップ4: 自由チャレンジ</h2>
+        <h2 className="text-3xl font-bold text-gray-900 dark:text-white">ステップ3: 自由チャレンジ</h2>
       </div>
 
       <div className="space-y-6">


### PR DESCRIPTION
## Summary
- correct heading to step3

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f93ea11a48326a8222708c1738caf