### PR TITLE
Add grid-cols-16 support

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      gridTemplateColumns: {
+        '16': 'repeat(16, minmax(0, 1fr))',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## 目的
- Tailwind で 16 列のグリッドを使えるように設定
- AES 学習画面の S-Box 表示で `grid-cols-16` を利用
- Tailwind 設定ファイルの末尾に改行を追加

## テスト
- `npm run lint` *(エラー: unused-vars など)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f93f4eedc8326821c3c9762e6c6f3